### PR TITLE
#9 - Diffscidvariables optimization

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,9 +12,9 @@ Fixes # (issue)
 
 Please select the right one.
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected or existing DBs to be re-synced)
+- [ ] (Patch) Bug fix (non-breaking change which fixes an issue)
+- [ ] (Minor) New feature (non-breaking change which adds functionality)
+- [ ] (Major) Breaking change (fix or feature that would cause existing functionality to not work as expected or existing DBs to be re-synced)
 - [ ] This change requires a documentation update
 
 ## Which part is impacted ?
@@ -31,6 +31,7 @@ Please select the right one.
 - [ ] I have commented my code
 - [ ] My changes generate no new warnings
 - [ ] I have performed a full chain re-scan (if applicable)
+- [ ] I have updated the semver version (structures.Version)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ var shasum string
 shasum = fmt.Sprintf("%x", sha1.Sum([]byte("gnomon")))  // shasum can be used to unique a given db directory if you choose, can use normal words as well - whatever your 
 
 db_name := fmt.Sprintf("%s_%s.db", "GNOMON", shasum)
-current_path, err := os.Getwd()
+wd, err := os.Getwd()
 if err != nil {
-    log.Printf("%v\n", err)
+  logger.Fatalf("[Main] Err getting working directory: %v", err)
 }
-db_path := filepath.Join(current_path, db_name)
+db_path := filepath.Join(wd, "gnomondb")
 Bbs_backend, err = storage.NewBBoltDB(db_path, db_name)
+if err != nil {
+  logger.Fatalf("[Main] Err creating boltdb: %v", err)
+}
 ```
 
 #### GravitonDB

--- a/cmd/gnomonindexer/gnomonindexer.go
+++ b/cmd/gnomonindexer/gnomonindexer.go
@@ -267,12 +267,15 @@ func main() {
 			shasum = fmt.Sprintf("%x", sha1.Sum([]byte(csearch_filter)))
 		}
 		db_name := fmt.Sprintf("%s_%s.db", "GNOMON", shasum)
-		current_path, err := os.Getwd()
+		wd, err := os.Getwd()
 		if err != nil {
 			logger.Fatalf("[Main] Err getting working directory: %v", err)
 		}
-		db_path := filepath.Join(current_path, db_name)
+		db_path := filepath.Join(wd, "gnomondb")
 		Bbs_backend, err = storage.NewBBoltDB(db_path, db_name)
+		if err != nil {
+			logger.Fatalf("[Main] Err creating boltdb: %v", err)
+		}
 	}
 
 	// API

--- a/cmd/gnomonindexer/gnomonindexer.go
+++ b/cmd/gnomonindexer/gnomonindexer.go
@@ -59,7 +59,6 @@ Options:
   --dbtype=<boltdb>     Defines type of database. 'gravdb' or 'boltdb'. If gravdb, expect LARGE local storage if running in daemon mode until further optimized later. [--ramstore can only be valid with gravdb]. Defaults to boltdb.
   --ramstore     True/false value to define if the db [only if gravdb] will be used in RAM or on disk. Keep in mind on close, the RAM store will be non-persistent.
   --num-parallel-blocks=<5>     Defines the number of parallel blocks to index in daemonmode. While a lower limit of 1 is defined, there is no hardcoded upper limit. Be mindful the higher set, the greater the daemon load potentially (highly recommend local nodes if this is greater than 1-5)
-  --enable-experimental-scvarstore     Enables storing of the scid variables per interaction as a difference rather than the entire store. Much less storage usage, however unoptimized diff and will take significantly longer currently. This option will be removed in future.
   --remove-api-throttle     Removes the api throttle against number of sc variables, sc invoke data etc. to return
   --sf-scid-exclusions=<"a05395bb0cf77adc850928b0db00eb5ca7a9ccbafd9a38d021c8d299ad5ce1a4;;;c9d23d2fc3aaa8e54e238a2218c0e5176a6e48780920fd8474fac5b0576110a2">     Defines a scid or scids (use const separator [default ';;;']) to be excluded from indexing regardless of search-filter. If nothing is defined, all scids that match the search-filter will be indexed.
   --skip-gnomonsc-index     If the gnomonsc is caught within the supplied search filter, you can skip indexing that SC given the size/depth of calls to that SC for increased sync times.
@@ -236,12 +235,6 @@ func main() {
 		ramstore = true
 	}
 
-	// Enable experimental (to be removed later) sc variable diff storage. Saves space, computation takes time until it is optimized for general use and this option goes away
-	var experimentalscvars bool
-	if arguments["--enable-experimental-scvarstore"] != nil && arguments["--enable-experimental-scvarstore"].(bool) == true {
-		experimentalscvars = true
-	}
-
 	// Enable api throttle (or disable if set)
 	api_throttle := true
 	if arguments["--remove-api-throttle"] != nil && arguments["--remove-api-throttle"].(bool) == true {
@@ -320,7 +313,7 @@ func main() {
 	go apis.Start()
 
 	// Start default indexer based on search_filter params
-	defaultIndexer := indexer.NewIndexer(Graviton_backend, Bbs_backend, Gnomon.DBType, search_filter, last_indexedheight, daemon_endpoint, Gnomon.RunMode, mbl, closeondisconnect, fastsync, experimentalscvars, sf_scid_exclusions)
+	defaultIndexer := indexer.NewIndexer(Graviton_backend, Bbs_backend, Gnomon.DBType, search_filter, last_indexedheight, daemon_endpoint, Gnomon.RunMode, mbl, closeondisconnect, fastsync, sf_scid_exclusions)
 
 	switch Gnomon.RunMode {
 	case "daemon":

--- a/cmd/gnomonsc/gnomonsc.go
+++ b/cmd/gnomonsc/gnomonsc.go
@@ -34,7 +34,6 @@ var pollTime time.Duration
 var thAddition int64
 var gnomonIndexes []*structures.GnomonSCIDQuery
 var mux sync.Mutex
-var version = "0.1.2"
 
 var command_line string = `Gnomon
 Gnomon SC Index Registration Service: As the Gnomon SCID owner, you can automatically poll your local gnomon instance for new SCIDs to append to the index SC
@@ -68,7 +67,7 @@ func main() {
 	ringsize = uint64(2)
 
 	// Inspect argument(s)
-	arguments, err := docopt.ParseArgs(command_line, nil, version)
+	arguments, err := docopt.ParseArgs(command_line, nil, structures.Version.String())
 
 	if err != nil {
 		log.Fatalf("[Main] Error while parsing arguments err: %s", err)

--- a/cmd/gnomonsc/gnomonsc.go
+++ b/cmd/gnomonsc/gnomonsc.go
@@ -246,10 +246,10 @@ func runGnomonIndexer(derodendpoint string, gnomonendpoint string, search_filter
 
 	// If we can gather the current height from /api/getinfo then start-topoheight will be passed and fastsync not used. This saves time to not check all SCIDs from gnomon SC. Otherwise default back to "slow and steady" method.
 	if currheight > 0 {
-		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, currheight, derodendpoint, "daemon", false, false, false, false, sf_scid_exclusions)
+		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, currheight, derodendpoint, "daemon", false, false, false, sf_scid_exclusions)
 		defaultIndexer.StartDaemonMode(1)
 	} else {
-		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, int64(1), derodendpoint, "daemon", false, false, true, false, sf_scid_exclusions)
+		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, int64(1), derodendpoint, "daemon", false, false, true, sf_scid_exclusions)
 		defaultIndexer.StartDaemonMode(1)
 	}
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -142,6 +142,9 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 	switch indexer.DBType {
 	case "gravdb":
 		storedindex = indexer.GravDBBackend.GetLastIndexHeight()
+		if err != nil {
+			logger.Fatalf("[gravdb-StartDaemonMode] Could not get last index height - %v", err)
+		}
 	case "boltdb":
 		storedindex, err = indexer.BBSBackend.GetLastIndexHeight()
 		if err != nil {
@@ -274,7 +277,7 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 					time.Sleep(writeWait)
 				}
 				indexer.BBSBackend.Writing = 1
-				indexer.BBSBackend.Writer = "StartDaemonMode"
+				//indexer.BBSBackend.Writer = "StartDaemonMode"
 				_, err := indexer.BBSBackend.StoreOwner(vi, "")
 				if err != nil {
 					logger.Errorf("[StartDaemonMode-hardcodedscids] Error storing owner: %v", err)
@@ -291,7 +294,7 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 					}
 				}
 				indexer.BBSBackend.Writing = 0
-				indexer.BBSBackend.Writer = ""
+				//indexer.BBSBackend.Writer = ""
 			}
 		}
 	}
@@ -456,10 +459,10 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 										time.Sleep(writeWait)
 									}
 									indexer.BBSBackend.Writing = 1
-									indexer.BBSBackend.Writer = "StartDaemonMode"
+									//indexer.BBSBackend.Writer = "StartDaemonMode"
 									indexer.BBSBackend.StoreLastIndexHeight(currIndex)
 									indexer.BBSBackend.Writing = 0
-									indexer.BBSBackend.Writer = ""
+									//indexer.BBSBackend.Writer = ""
 								}
 								// Break out on closing call
 								break
@@ -505,10 +508,10 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 												time.Sleep(writeWait)
 											}
 											indexer.BBSBackend.Writing = 1
-											indexer.BBSBackend.Writer = "StartDaemonMode"
+											//indexer.BBSBackend.Writer = "StartDaemonMode"
 											indexer.BBSBackend.StoreLastIndexHeight(rewindIndex)
 											indexer.BBSBackend.Writing = 0
-											indexer.BBSBackend.Writer = ""
+											//indexer.BBSBackend.Writer = ""
 										}
 
 										// Break out on closing call
@@ -672,10 +675,10 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 						time.Sleep(writeWait)
 					}
 					indexer.BBSBackend.Writing = 1
-					indexer.BBSBackend.Writer = "StartDaemonMode"
+					//indexer.BBSBackend.Writer = "StartDaemonMode"
 					indexer.BBSBackend.StoreLastIndexHeight(indexer.LastIndexedHeight)
 					indexer.BBSBackend.Writing = 0
-					indexer.BBSBackend.Writer = ""
+					//indexer.BBSBackend.Writer = ""
 				}
 			}
 		}
@@ -1048,16 +1051,16 @@ func (indexer *Indexer) indexBlock(blid string, topoheight int64) (blockTxns *st
 				}
 
 				indexer.BBSBackend.Writing = 1
-				indexer.BBSBackend.Writer = "IndexBlock"
+				//indexer.BBSBackend.Writer = "IndexBlock"
 				_, err2 = indexer.BBSBackend.StoreMiniblockDetailsByHash(blid, mbldetails)
 				if err2 != nil {
 					logger.Errorf("[indexBlock] Error storing miniblock details for blid %v", err2)
 					indexer.BBSBackend.Writing = 0
-					indexer.BBSBackend.Writer = ""
+					//indexer.BBSBackend.Writer = ""
 					return blockTxns, err2
 				}
 				indexer.BBSBackend.Writing = 0
-				indexer.BBSBackend.Writer = ""
+				//indexer.BBSBackend.Writer = ""
 			}
 		}
 	}
@@ -1215,10 +1218,10 @@ func (indexer *Indexer) IndexTxn(blTxns *structures.BlockTxns, noStore bool) (bl
 											time.Sleep(writeWait)
 										}
 										indexer.BBSBackend.Writing = 1
-										indexer.BBSBackend.Writer = "IndexTxn"
+										//indexer.BBSBackend.Writer = "IndexTxn"
 										indexer.BBSBackend.StoreNormalTxWithSCIDByAddr(v, &structures.NormalTXWithSCIDParse{Txid: blTxns.Tx_hashes[i].String(), Scid: tx.Payloads[j].SCID.String(), Fees: sc_fees, Height: int64(blTxns.Topoheight)})
 										indexer.BBSBackend.Writing = 0
-										indexer.BBSBackend.Writer = ""
+										//indexer.BBSBackend.Writer = ""
 									}
 								}
 							}
@@ -1407,7 +1410,7 @@ func (indexer *Indexer) indexTxCounts(regTxCount int64, burnTxCount int64, normT
 			time.Sleep(writeWait)
 		}
 		indexer.BBSBackend.Writing = 1
-		indexer.BBSBackend.Writer = "IndexTxCounts"
+		//indexer.BBSBackend.Writer = "IndexTxCounts"
 		if regTxCount > 0 && !indexer.Fastsync {
 			// Load from mem existing regTxCount and append new value
 			currRegTxCount := indexer.BBSBackend.GetTxCount("registration")
@@ -1415,7 +1418,7 @@ func (indexer *Indexer) indexTxCounts(regTxCount int64, burnTxCount int64, normT
 			if err != nil {
 				logger.Errorf("[indexBlock] ERROR - Error storing registration tx count. DB '%v' - this block count '%v' - total '%v'", currRegTxCount, regTxCount, regTxCount+currRegTxCount)
 				indexer.BBSBackend.Writing = 0
-				indexer.BBSBackend.Writer = ""
+				//indexer.BBSBackend.Writer = ""
 				return err
 			}
 		}
@@ -1427,7 +1430,7 @@ func (indexer *Indexer) indexTxCounts(regTxCount int64, burnTxCount int64, normT
 			if err != nil {
 				logger.Errorf("[indexBlock] ERROR - Error storing burn tx count. DB '%v' - this block count '%v' - total '%v'", currBurnTxCount, burnTxCount, regTxCount+currBurnTxCount)
 				indexer.BBSBackend.Writing = 0
-				indexer.BBSBackend.Writer = ""
+				//indexer.BBSBackend.Writer = ""
 				return err
 			}
 		}
@@ -1439,12 +1442,12 @@ func (indexer *Indexer) indexTxCounts(regTxCount int64, burnTxCount int64, normT
 			if err != nil {
 				logger.Errorf("[indexBlock] ERROR - Error storing normal tx count. DB '%v' - this block count '%v' - total '%v'", currNormTxCount, currNormTxCount, normTxCount+currNormTxCount)
 				indexer.BBSBackend.Writing = 0
-				indexer.BBSBackend.Writer = ""
+				//indexer.BBSBackend.Writer = ""
 				return err
 			}
 		}
 		indexer.BBSBackend.Writing = 0
-		indexer.BBSBackend.Writer = ""
+		//indexer.BBSBackend.Writer = ""
 	}
 
 	return nil
@@ -1566,7 +1569,7 @@ func (indexer *Indexer) indexInvokes(bl_sctxs []structures.SCTXParse, bl_txns *s
 								time.Sleep(writeWait)
 							}
 							indexer.BBSBackend.Writing = 1
-							indexer.BBSBackend.Writer = "IndexInvokes"
+							//indexer.BBSBackend.Writer = "IndexInvokes"
 
 							_, err := indexer.BBSBackend.StoreOwner(bl_sctxs[i].Scid, bl_sctxs[i].Sender)
 							if err != nil {
@@ -1589,7 +1592,7 @@ func (indexer *Indexer) indexInvokes(bl_sctxs []structures.SCTXParse, bl_txns *s
 								logger.Errorf("[indexInvokes-installsc] ERR - storing scid interaction height: %v", err)
 							}
 							indexer.BBSBackend.Writing = 0
-							indexer.BBSBackend.Writer = ""
+							//indexer.BBSBackend.Writer = ""
 						}
 
 						//logger.Debugf("[IndexInvokes] SCID: %v ; Sender: %v ; Entrypoint: %v ; topoheight : %v ; info: %v", bl_sctxs[i].Scid, bl_sctxs[i].Sender, bl_sctxs[i].Entrypoint, topoheight, &bl_sctxs[i])
@@ -1621,10 +1624,10 @@ func (indexer *Indexer) indexInvokes(bl_sctxs []structures.SCTXParse, bl_txns *s
 									time.Sleep(writeWait)
 								}
 								indexer.BBSBackend.Writing = 1
-								indexer.BBSBackend.Writer = "IndexInvokes"
+								//indexer.BBSBackend.Writer = "IndexInvokes"
 								indexer.BBSBackend.StoreInvalidSCIDDeploys(bl_sctxs[i].Scid, bl_sctxs[i].Fees)
 								indexer.BBSBackend.Writing = 0
-								indexer.BBSBackend.Writer = ""
+								//indexer.BBSBackend.Writer = ""
 							}
 						}
 					}
@@ -1669,7 +1672,7 @@ func (indexer *Indexer) indexInvokes(bl_sctxs []structures.SCTXParse, bl_txns *s
 								time.Sleep(writeWait)
 							}
 							indexer.BBSBackend.Writing = 1
-							indexer.BBSBackend.Writer = "IndexInvokesOwnerStore"
+							//indexer.BBSBackend.Writer = "IndexInvokesOwnerStore"
 
 							_, err = indexer.BBSBackend.StoreOwner(bl_sctxs[i].Scid, "")
 							if err != nil {
@@ -1677,7 +1680,7 @@ func (indexer *Indexer) indexInvokes(bl_sctxs []structures.SCTXParse, bl_txns *s
 							}
 
 							indexer.BBSBackend.Writing = 0
-							indexer.BBSBackend.Writer = ""
+							//indexer.BBSBackend.Writer = ""
 						}
 					}
 				}
@@ -1813,14 +1816,14 @@ func (indexer *Indexer) indexInvokes(bl_sctxs []structures.SCTXParse, bl_txns *s
 									time.Sleep(writeWait)
 								}
 								indexer.BBSBackend.Writing = 1
-								indexer.BBSBackend.Writer = "IndexInvokesDetailsStore"
+								//indexer.BBSBackend.Writer = "IndexInvokesDetailsStore"
 
 								_, err := indexer.BBSBackend.StoreInvokeDetails(bl_sctxs[i].Scid, bl_sctxs[i].Sender, bl_sctxs[i].Entrypoint, bl_txns.Topoheight, &currsctx)
 								if err != nil {
 									logger.Errorf("[indexInvokes] Err storing invoke details. Err: %v", err)
 									time.Sleep(5 * time.Second)
 									indexer.BBSBackend.Writing = 0
-									indexer.BBSBackend.Writer = ""
+									//indexer.BBSBackend.Writer = ""
 									return err
 								}
 
@@ -1851,7 +1854,7 @@ func (indexer *Indexer) indexInvokes(bl_sctxs []structures.SCTXParse, bl_txns *s
 								}
 
 								indexer.BBSBackend.Writing = 0
-								indexer.BBSBackend.Writer = ""
+								//indexer.BBSBackend.Writer = ""
 							}
 						}
 
@@ -2027,13 +2030,13 @@ func (indexer *Indexer) getInfo() {
 							time.Sleep(writeWait)
 						}
 						indexer.BBSBackend.Writing = 1
-						indexer.BBSBackend.Writer = "getInfo"
+						//indexer.BBSBackend.Writer = "getInfo"
 						_, err := indexer.BBSBackend.StoreGetInfoDetails(structureGetInfo)
 						if err != nil {
 							logger.Errorf("[getInfo] ERROR - GetInfo store failed: %v", err)
 						}
 						indexer.BBSBackend.Writing = 0
-						indexer.BBSBackend.Writer = ""
+						//indexer.BBSBackend.Writer = ""
 					}
 				}
 			} else {
@@ -2080,13 +2083,13 @@ func (indexer *Indexer) getInfo() {
 					time.Sleep(writeWait)
 				}
 				indexer.BBSBackend.Writing = 1
-				indexer.BBSBackend.Writer = "getInfo"
+				//indexer.BBSBackend.Writer = "getInfo"
 				_, err := indexer.BBSBackend.StoreGetInfoDetails(structureGetInfo)
 				if err != nil {
 					logger.Errorf("[getInfo] ERROR - GetInfo store failed: %v", err)
 				}
 				indexer.BBSBackend.Writing = 0
-				indexer.BBSBackend.Writer = ""
+				//indexer.BBSBackend.Writer = ""
 			}
 		}
 		indexer.Lock()
@@ -3232,11 +3235,11 @@ func (ind *Indexer) Close() {
 			time.Sleep(writeWait)
 		}
 		ind.BBSBackend.Writing = 1
-		ind.BBSBackend.Writer = "Close"
+		//ind.BBSBackend.Writer = "Close"
 		ind.BBSBackend.DB.Sync()
 		ind.BBSBackend.DB.Close()
 		ind.BBSBackend.Writing = 0
-		ind.BBSBackend.Writer = ""
+		//ind.BBSBackend.Writer = ""
 	}
 }
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -3085,7 +3085,7 @@ func (indexer *Indexer) DiffSCIDVariables(varset1 []*structures.SCIDVariable, va
 	}
 
 	// Checking through the delete set we can assume (given the input to the diff) that any values returned can simply be stored with nil values as they were deleted
-	for mak, _ := range delete_map_actual {
+	for mak := range delete_map_actual {
 		co := &structures.SCIDVariable{}
 
 		// String data coming out of the compare seems to append "" around strings, so we pop those off to at least compare

--- a/storage/bbolt.go
+++ b/storage/bbolt.go
@@ -21,7 +21,7 @@ type BboltStore struct {
 	DB      *bolt.DB
 	DBPath  string
 	Writing int
-	Writer  string
+	//Writer  string
 	Closing bool
 	Buckets []string
 }

--- a/storage/bbolt.go
+++ b/storage/bbolt.go
@@ -556,6 +556,19 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 			}
 			for _, vs := range results[v] {
 				switch ckey := vs.Key.(type) {
+				case float64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[uint64(ckey)] = uint64(cval)
+					case uint64:
+						vs2k[uint64(ckey)] = cval
+					case string:
+						vs2k[uint64(ckey)] = cval
+					default:
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
+					}
 				case uint64:
 					switch cval := vs.Value.(type) {
 					case float64:
@@ -584,7 +597,7 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					}
 				default:
 					if ckey != nil {
-						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string, uint64 or float64.", ckey)
 					}
 				}
 			}
@@ -599,6 +612,20 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 			co := &structures.SCIDVariable{}
 
 			switch ckey := k.(type) {
+			case float64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = uint64(ckey)
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				case string:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", uint64(ckey)))
+				}
 			case uint64:
 				switch cval := v.(type) {
 				case float64:
@@ -611,7 +638,7 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			case string:
 				switch cval := v.(type) {
@@ -625,7 +652,7 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			}
 
@@ -675,6 +702,19 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 		for _, v := range heights {
 			for _, vs := range results[v] {
 				switch ckey := vs.Key.(type) {
+				case float64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[uint64(ckey)] = uint64(cval)
+					case uint64:
+						vs2k[uint64(ckey)] = cval
+					case string:
+						vs2k[uint64(ckey)] = cval
+					default:
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
+					}
 				case uint64:
 					switch cval := vs.Value.(type) {
 					case float64:
@@ -703,7 +743,7 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					}
 				default:
 					if ckey != nil {
-						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string, uint64 or float64.", ckey)
 					}
 				}
 			}
@@ -718,6 +758,20 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 			co := &structures.SCIDVariable{}
 
 			switch ckey := k.(type) {
+			case float64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = uint64(ckey)
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				case string:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", uint64(ckey)))
+				}
 			case uint64:
 				switch cval := v.(type) {
 				case float64:
@@ -730,7 +784,7 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			case string:
 				switch cval := v.(type) {
@@ -744,7 +798,7 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			}
 

--- a/storage/bbolt.go
+++ b/storage/bbolt.go
@@ -565,7 +565,9 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				case string:
 					switch cval := vs.Value.(type) {
@@ -576,10 +578,14 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				default:
-					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					if ckey != nil {
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					}
 				}
 			}
 		}
@@ -678,7 +684,9 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				case string:
 					switch cval := vs.Value.(type) {
@@ -689,10 +697,14 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				default:
-					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					if ckey != nil {
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					}
 				}
 			}
 		}

--- a/storage/bbolt.go
+++ b/storage/bbolt.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -26,13 +28,17 @@ type BboltStore struct {
 // local logger
 var logger *logrus.Entry
 
-func NewBBoltDB(dbPath string, dbName string) (*BboltStore, error) {
+func NewBBoltDB(dbPath, dbName string) (*BboltStore, error) {
 	var err error
 	var Bbolt_backend *BboltStore = &BboltStore{}
 
 	logger = structures.Logger.WithFields(logrus.Fields{})
 
-	Bbolt_backend.DB, err = bolt.Open(dbName, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	if err := os.MkdirAll(dbPath, 0700); err != nil {
+		return nil, fmt.Errorf("directory creation err %s - dirpath %s", err, dbPath)
+	}
+	db_path := filepath.Join(dbPath, dbName)
+	Bbolt_backend.DB, err = bolt.Open(db_path, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		return Bbolt_backend, fmt.Errorf("[NewBBoltDB] Coult not create bbolt db store: %v", err)
 	}
@@ -543,28 +549,81 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 			return heights[i] < heights[j]
 		})
 
-		for k, v := range heights {
+		vs2k := make(map[interface{}]interface{})
+		for _, v := range heights {
 			if v > topoheight {
-				// Only return all the data relevant to up to the defined height
 				break
 			}
 			for _, vs := range results[v] {
-				kfound := false
-				for _, va := range hVars {
-					if va.Key == vs.Key {
-						// If key already exists in tracked slice, set the 'latest' value to the value
-						kfound = true
-
-						logger.Debugf("[GetAllSCIDVariableDetails] Key '%v' found, setting value from '%v' to '%v' via height %v", fmt.Sprintf("%v", va.Key), fmt.Sprintf("%v", va.Value), fmt.Sprintf("%v", vs.Value), k)
-
-						va.Value = vs.Value
-						break
+				switch ckey := vs.Key.(type) {
+				case uint64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
 					}
-				}
-				if !kfound {
-					hVars = append(hVars, vs)
+				case string:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+					}
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
 				}
 			}
+		}
+
+		for k, v := range vs2k {
+			// If value is nil, no reason to add.
+			if v == nil || k == nil {
+				logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
+				continue
+			}
+			co := &structures.SCIDVariable{}
+
+			switch ckey := k.(type) {
+			case uint64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			case string:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			}
+
+			hVars = append(hVars, co)
 		}
 	}
 
@@ -606,24 +665,78 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 			return heights[i] < heights[j]
 		})
 
-		for k, v := range heights {
+		vs2k := make(map[interface{}]interface{})
+		for _, v := range heights {
 			for _, vs := range results[v] {
-				kfound := false
-				for _, va := range hVars {
-					if va.Key == vs.Key {
-						// If key already exists in tracked slice, set the 'latest' value to the value
-						kfound = true
-
-						logger.Debugf("[GetAllSCIDVariableDetails] Key '%v' found, setting value from '%v' to '%v' via height %v", fmt.Sprintf("%v", va.Key), fmt.Sprintf("%v", va.Value), fmt.Sprintf("%v", vs.Value), k)
-
-						va.Value = vs.Value
-						break
+				switch ckey := vs.Key.(type) {
+				case uint64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
 					}
-				}
-				if !kfound {
-					hVars = append(hVars, vs)
+				case string:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+					}
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
 				}
 			}
+		}
+
+		for k, v := range vs2k {
+			// If value is nil, no reason to add.
+			if v == nil || k == nil {
+				logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
+				continue
+			}
+			co := &structures.SCIDVariable{}
+
+			switch ckey := k.(type) {
+			case uint64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			case string:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			}
+
+			hVars = append(hVars, co)
 		}
 	}
 

--- a/storage/bbolt.go
+++ b/storage/bbolt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -566,7 +567,9 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 						vs2k[uint64(ckey)] = cval
 					default:
 						if cval != nil {
-							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+							logger.Errorf("[GetSCIDVariableDetailsAtTopoheight] Value '%v' does not match string, uint64 or float64.", cval)
+						} else {
+							vs2k[uint64(ckey)] = cval
 						}
 					}
 				case uint64:
@@ -579,7 +582,9 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 						vs2k[ckey] = cval
 					default:
 						if cval != nil {
-							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+							logger.Errorf("[GetSCIDVariableDetailsAtTopoheight] Value '%v' does not match string, uint64 or float64.", cval)
+						} else {
+							vs2k[ckey] = cval
 						}
 					}
 				case string:
@@ -592,12 +597,14 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 						vs2k[ckey] = cval
 					default:
 						if cval != nil {
-							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+							logger.Errorf("[GetSCIDVariableDetailsAtTopoheight] Value '%v' does not match string, uint64 or float64.", cval)
+						} else {
+							vs2k[ckey] = cval
 						}
 					}
 				default:
 					if ckey != nil {
-						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string, uint64 or float64.", ckey)
+						logger.Errorf("[GetSCIDVariableDetailsAtTopoheight] Key '%v' does not match string, uint64 or float64.", ckey)
 					}
 				}
 			}
@@ -605,8 +612,8 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 
 		for k, v := range vs2k {
 			// If value is nil, no reason to add.
-			if v == nil || k == nil {
-				logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
+			if v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil()) || k == nil || (reflect.ValueOf(k).Kind() == reflect.Ptr && reflect.ValueOf(k).IsNil()) {
+				//logger.Debugf("[GetSCIDVariableDetailsAtTopoheight] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
 				continue
 			}
 			co := &structures.SCIDVariable{}
@@ -624,7 +631,8 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					co.Key = uint64(ckey)
 					co.Value = cval
 				default:
-					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", uint64(ckey)))
+					logger.Errorf("[GetSCIDVariableDetailsAtTopoheight] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", uint64(ckey)))
+					continue
 				}
 			case uint64:
 				switch cval := v.(type) {
@@ -638,7 +646,8 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetSCIDVariableDetailsAtTopoheight] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					continue
 				}
 			case string:
 				switch cval := v.(type) {
@@ -652,7 +661,8 @@ func (bbs *BboltStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheigh
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetSCIDVariableDetailsAtTopoheight] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					continue
 				}
 			}
 
@@ -713,6 +723,8 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					default:
 						if cval != nil {
 							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						} else {
+							vs2k[uint64(ckey)] = cval
 						}
 					}
 				case uint64:
@@ -726,6 +738,8 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					default:
 						if cval != nil {
 							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						} else {
+							vs2k[ckey] = cval
 						}
 					}
 				case string:
@@ -739,6 +753,8 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					default:
 						if cval != nil {
 							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						} else {
+							vs2k[ckey] = cval
 						}
 					}
 				default:
@@ -751,8 +767,8 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 
 		for k, v := range vs2k {
 			// If value is nil, no reason to add.
-			if v == nil || k == nil {
-				logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
+			if v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil()) || k == nil || (reflect.ValueOf(k).Kind() == reflect.Ptr && reflect.ValueOf(k).IsNil()) {
+				//logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
 				continue
 			}
 			co := &structures.SCIDVariable{}
@@ -771,6 +787,7 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					co.Value = cval
 				default:
 					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", uint64(ckey)))
+					continue
 				}
 			case uint64:
 				switch cval := v.(type) {
@@ -785,6 +802,7 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					co.Value = cval
 				default:
 					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					continue
 				}
 			case string:
 				switch cval := v.(type) {
@@ -799,6 +817,7 @@ func (bbs *BboltStore) GetAllSCIDVariableDetails(scid string) (hVars []*structur
 					co.Value = cval
 				default:
 					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					continue
 				}
 			}
 

--- a/storage/gravdb.go
+++ b/storage/gravdb.go
@@ -921,28 +921,81 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 			return heights[i] < heights[j]
 		})
 
-		for k, v := range heights {
+		vs2k := make(map[interface{}]interface{})
+		for _, v := range heights {
 			if v > topoheight {
-				// Only return all the data relevant to up to the defined height
 				break
 			}
 			for _, vs := range results[v] {
-				kfound := false
-				for _, va := range hVars {
-					if va.Key == vs.Key {
-						// If key already exists in tracked slice, set the 'latest' value to the value
-						kfound = true
-
-						logger.Debugf("[GetAllSCIDVariableDetails] Key '%v' found, setting value from '%v' to '%v' via height %v", fmt.Sprintf("%v", va.Key), fmt.Sprintf("%v", va.Value), fmt.Sprintf("%v", vs.Value), k)
-
-						va.Value = vs.Value
-						break
+				switch ckey := vs.Key.(type) {
+				case uint64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
 					}
-				}
-				if !kfound {
-					hVars = append(hVars, vs)
+				case string:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+					}
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
 				}
 			}
+		}
+
+		for k, v := range vs2k {
+			// If value is nil, no reason to add.
+			if v == nil || k == nil {
+				logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
+				continue
+			}
+			co := &structures.SCIDVariable{}
+
+			switch ckey := k.(type) {
+			case uint64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			case string:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			}
+
+			hVars = append(hVars, co)
 		}
 	}
 
@@ -992,24 +1045,78 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 			return heights[i] < heights[j]
 		})
 
-		for k, v := range heights {
+		vs2k := make(map[interface{}]interface{})
+		for _, v := range heights {
 			for _, vs := range results[v] {
-				kfound := false
-				for _, va := range hVars {
-					if va.Key == vs.Key {
-						// If key already exists in tracked slice, set the 'latest' value to the value
-						kfound = true
-
-						logger.Debugf("[GetAllSCIDVariableDetails] Key '%v' found, setting value from '%v' to '%v' via height %v", fmt.Sprintf("%v", va.Key), fmt.Sprintf("%v", va.Value), fmt.Sprintf("%v", vs.Value), k)
-
-						va.Value = vs.Value
-						break
+				switch ckey := vs.Key.(type) {
+				case uint64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
 					}
-				}
-				if !kfound {
-					hVars = append(hVars, vs)
+				case string:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[ckey] = uint64(cval)
+					case uint64:
+						vs2k[ckey] = cval
+					case string:
+						vs2k[ckey] = cval
+					default:
+						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+					}
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
 				}
 			}
+		}
+
+		for k, v := range vs2k {
+			// If value is nil, no reason to add.
+			if v == nil || k == nil {
+				logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", v), fmt.Sprintf("%v", k))
+				continue
+			}
+			co := &structures.SCIDVariable{}
+
+			switch ckey := k.(type) {
+			case uint64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			case string:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = ckey
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = ckey
+					co.Value = cval
+				case string:
+					co.Key = ckey
+					co.Value = cval
+				default:
+					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+				}
+			}
+
+			hVars = append(hVars, co)
 		}
 	}
 

--- a/storage/gravdb.go
+++ b/storage/gravdb.go
@@ -928,6 +928,19 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 			}
 			for _, vs := range results[v] {
 				switch ckey := vs.Key.(type) {
+				case float64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[uint64(ckey)] = uint64(cval)
+					case uint64:
+						vs2k[uint64(ckey)] = cval
+					case string:
+						vs2k[uint64(ckey)] = cval
+					default:
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
+					}
 				case uint64:
 					switch cval := vs.Value.(type) {
 					case float64:
@@ -956,7 +969,7 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 					}
 				default:
 					if ckey != nil {
-						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string, uint64 or float64.", ckey)
 					}
 				}
 			}
@@ -971,6 +984,20 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 			co := &structures.SCIDVariable{}
 
 			switch ckey := k.(type) {
+			case float64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = uint64(ckey)
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				case string:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", uint64(ckey)))
+				}
 			case uint64:
 				switch cval := v.(type) {
 				case float64:
@@ -983,7 +1010,7 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			case string:
 				switch cval := v.(type) {
@@ -997,7 +1024,7 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			}
 
@@ -1055,6 +1082,19 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 		for _, v := range heights {
 			for _, vs := range results[v] {
 				switch ckey := vs.Key.(type) {
+				case float64:
+					switch cval := vs.Value.(type) {
+					case float64:
+						vs2k[uint64(ckey)] = uint64(cval)
+					case uint64:
+						vs2k[uint64(ckey)] = cval
+					case string:
+						vs2k[uint64(ckey)] = cval
+					default:
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
+					}
 				case uint64:
 					switch cval := vs.Value.(type) {
 					case float64:
@@ -1083,7 +1123,7 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 					}
 				default:
 					if ckey != nil {
-						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string, uint64 or float64.", ckey)
 					}
 				}
 			}
@@ -1098,6 +1138,20 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 			co := &structures.SCIDVariable{}
 
 			switch ckey := k.(type) {
+			case float64:
+				switch cval := v.(type) {
+				case float64:
+					co.Key = uint64(ckey)
+					co.Value = uint64(cval)
+				case uint64:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				case string:
+					co.Key = uint64(ckey)
+					co.Value = cval
+				default:
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", uint64(ckey)))
+				}
 			case uint64:
 				switch cval := v.(type) {
 				case float64:
@@ -1110,7 +1164,7 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			case string:
 				switch cval := v.(type) {
@@ -1124,7 +1178,7 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 					co.Key = ckey
 					co.Value = cval
 				default:
-					logger.Debugf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' is nil. Continuing.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
+					logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' or Key '%v' does not match string, uint64 or float64.", fmt.Sprintf("%v", cval), fmt.Sprintf("%v", ckey))
 				}
 			}
 

--- a/storage/gravdb.go
+++ b/storage/gravdb.go
@@ -937,7 +937,9 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				case string:
 					switch cval := vs.Value.(type) {
@@ -948,10 +950,14 @@ func (g *GravitonStore) GetSCIDVariableDetailsAtTopoheight(scid string, topoheig
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				default:
-					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					if ckey != nil {
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					}
 				}
 			}
 		}
@@ -1058,7 +1064,9 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				case string:
 					switch cval := vs.Value.(type) {
@@ -1069,10 +1077,14 @@ func (g *GravitonStore) GetAllSCIDVariableDetails(scid string) (hVars []*structu
 					case string:
 						vs2k[ckey] = cval
 					default:
-						logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						if cval != nil {
+							logger.Errorf("[GetAllSCIDVariableDetails] Value '%v' does not match string, uint64 or float64.", cval)
+						}
 					}
 				default:
-					logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					if ckey != nil {
+						logger.Errorf("[GetAllSCIDVariableDetails] Key '%v' does not match string or uint64.", ckey)
+					}
 				}
 			}
 		}

--- a/structures/structures.go
+++ b/structures/structures.go
@@ -19,7 +19,7 @@ const TESTNET_GNOMON_SCID = "c9d23d2fc3aaa8e54e238a2218c0e5176a6e48780920fd8474f
 const MAX_API_VAR_RETURN = 1024
 
 // Major.Minor.Patch-Iteration
-var Version = semver.MustParse("1.1.1-alpha.8")
+var Version = semver.MustParse("1.1.1-alpha.13")
 
 type SCTXParse struct {
 	Txid       string

--- a/structures/structures.go
+++ b/structures/structures.go
@@ -19,7 +19,7 @@ const TESTNET_GNOMON_SCID = "c9d23d2fc3aaa8e54e238a2218c0e5176a6e48780920fd8474f
 const MAX_API_VAR_RETURN = 1024
 
 // Major.Minor.Patch-Iteration
-var Version = semver.MustParse("1.1.1-alpha.13")
+var Version = semver.MustParse("1.1.1-alpha.27")
 
 type SCTXParse struct {
 	Txid       string

--- a/structures/structures.go
+++ b/structures/structures.go
@@ -3,6 +3,7 @@ package structures
 import (
 	"encoding/json"
 
+	"github.com/blang/semver/v4"
 	"github.com/deroproject/derohe/cryptography/crypto"
 	"github.com/deroproject/derohe/rpc"
 	"github.com/deroproject/derohe/transaction"
@@ -15,6 +16,10 @@ var Logger logrus.Logger
 // After daemon connection will check if mainnet/testnet and adjust accordingly
 const MAINNET_GNOMON_SCID = "a05395bb0cf77adc850928b0db00eb5ca7a9ccbafd9a38d021c8d299ad5ce1a4"
 const TESTNET_GNOMON_SCID = "c9d23d2fc3aaa8e54e238a2218c0e5176a6e48780920fd8474fac5b0576110a2"
+const MAX_API_VAR_RETURN = 1024
+
+// Major.Minor.Patch-Iteration
+var Version = semver.MustParse("1.1.1-alpha.8")
 
 type SCTXParse struct {
 	Txid       string
@@ -62,6 +67,7 @@ type APIConfig struct {
 	KeyFile              string `json:"keyFile"`
 	GetInfoKeyFile       string `json:"getInfoKeyFile"`
 	MBLLookup            bool   `json:"mbblookup"`
+	ApiThrottle          bool   `json:"apithrottle"`
 }
 
 type SCIDVariable struct {


### PR DESCRIPTION
## Description

Implemented scid variables diff() optimizations - #9 .

Integrated a ram store gravdb to inject the two varsets into separate trees and then run a [Diff()](https://github.com/deroproject/graviton/blob/master/diff_tree.go#L26) and report back the differences to the underlying db of choice. This procedure has removed the DB balloon effect of storing the full SC variable set at every interaction. Total sync storage for bbolt at height 2684197 is ~1.1GB.

## Type of change

Please select the right one.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected or existing DBs to be re-synced)
- [ ] This change requires a documentation update

## Which part is impacted ?

  - [x] Indexer
  - [ ] GnomonSC
  - [x] API
  - [x] Storage
  - [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [x] I have performed a full chain re-scan (if applicable)

## License

I am contributing & releasing the code under the MIT License (which can be found [here](https://raw.githubusercontent.com/civilware/Gnomon/main/LICENSE)).