### PR TITLE
Lighter fastsync t01

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Options:
   --enable-miniblock-lookup     True/false value to store all miniblocks and their respective details and miner addresses who found them. This currently REQUIRES a full node db in same directory
   --close-on-disconnect     True/false value to close out indexers in the event of daemon disconnect. Daemon will fail connections for 30 seconds and then close the indexer. This is for HA pairs or wanting services off on disconnect.
   --fastsync     True/false value to define loading at chain height and only keeping track of list of SCIDs and their respective up-to-date variable stores as it hits them. NOTE: You will not get all information and may rely on manual scid additions.
+  --skipfsrecheck     True/false value (only relevant when --fastsync is used) to define if SC validity should be re-checked from data coming via Gnomon SC index or not.
   --dbtype=<boltdb>     Defines type of database. 'gravdb' or 'boltdb'. If gravdb, expect LARGE local storage if running in daemon mode until further optimized later. [--ramstore can only be valid with gravdb]. Defaults to boltdb.
   --ramstore     True/false value to define if the db [only if gravdb] will be used in RAM or on disk. Keep in mind on close, the RAM store will be non-persistent.
   --num-parallel-blocks=<5>     Defines the number of parallel blocks to index in daemonmode. While a lower limit of 1 is defined, there is no hardcoded upper limit. Be mindful the higher set, the greater the daemon load potentially (highly recommend local nodes if this is greater than 1-5)

--- a/cmd/gnomonindexer/gnomonindexer.go
+++ b/cmd/gnomonindexer/gnomonindexer.go
@@ -1191,7 +1191,7 @@ func (g *GnomonServer) readline_loop(l *readline.Instance) (err error) {
 					logger.Printf("- Indexer '%v'", ki)
 					scidstoadd := make(map[string]*structures.FastSyncImport)
 					scidstoadd[line_parts[1]] = &structures.FastSyncImport{}
-					err = vi.AddSCIDToIndex(scidstoadd, false)
+					err = vi.AddSCIDToIndex(scidstoadd, false, false)
 					if err != nil {
 						logger.Printf("Err - %v", err)
 					}

--- a/cmd/gnomonindexer/gnomonindexer.go
+++ b/cmd/gnomonindexer/gnomonindexer.go
@@ -1191,7 +1191,7 @@ func (g *GnomonServer) readline_loop(l *readline.Instance) (err error) {
 					logger.Printf("- Indexer '%v'", ki)
 					scidstoadd := make(map[string]*structures.FastSyncImport)
 					scidstoadd[line_parts[1]] = &structures.FastSyncImport{}
-					err = vi.AddSCIDToIndex(scidstoadd, false, false)
+					err = vi.AddSCIDToIndex(scidstoadd, false, true)
 					if err != nil {
 						logger.Printf("Err - %v", err)
 					}

--- a/cmd/gnomonsc/gnomonsc.go
+++ b/cmd/gnomonsc/gnomonsc.go
@@ -246,10 +246,10 @@ func runGnomonIndexer(derodendpoint string, gnomonendpoint string, search_filter
 
 	// If we can gather the current height from /api/getinfo then start-topoheight will be passed and fastsync not used. This saves time to not check all SCIDs from gnomon SC. Otherwise default back to "slow and steady" method.
 	if currheight > 0 {
-		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, currheight, derodendpoint, "daemon", false, false, false, sf_scid_exclusions)
+		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, currheight, derodendpoint, "daemon", false, false, false, false, sf_scid_exclusions)
 		defaultIndexer.StartDaemonMode(1)
 	} else {
-		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, int64(1), derodendpoint, "daemon", false, false, true, sf_scid_exclusions)
+		defaultIndexer = indexer.NewIndexer(graviton_backend, nil, "gravdb", nil, int64(1), derodendpoint, "daemon", false, false, true, true, sf_scid_exclusions)
 		defaultIndexer.StartDaemonMode(1)
 	}
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -806,7 +806,6 @@ func (indexer *Indexer) AddSCIDToIndex(scidstoadd map[string]*structures.FastSyn
 	}
 	wg.Wait()
 
-	logger.Debugf("[AddSCIDToIndex] SCIDs to Index Stage: %v", scidstoindexstage)
 	for _, v := range scidstoindexstage {
 		if v.contains || varstoreonly {
 			// By returning valid variables of a given Scid (GetSC --> parse vars), we can conclude it is a valid SCID. Otherwise, skip adding to validated scids

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -761,7 +761,7 @@ func (indexer *Indexer) AddSCIDToIndex(scidstoadd map[string]*structures.FastSyn
 	for scid, fsi := range scidstoadd {
 		go func(scid string, fsi *structures.FastSyncImport) {
 			// Check if already validated
-			if scidExist(indexer.ValidatedSCs, scid) || indexer.Closing && !varstoreonly {
+			if (scidExist(indexer.ValidatedSCs, scid) || indexer.Closing) && !varstoreonly {
 				//logger.Debugf("[AddSCIDToIndex] SCID '%v' already in validated list.", scid)
 				wg.Done()
 
@@ -806,8 +806,9 @@ func (indexer *Indexer) AddSCIDToIndex(scidstoadd map[string]*structures.FastSyn
 	}
 	wg.Wait()
 
+	logger.Debugf("[AddSCIDToIndex] SCIDs to Index Stage: %v", scidstoindexstage)
 	for _, v := range scidstoindexstage {
-		if v.contains {
+		if v.contains || varstoreonly {
 			// By returning valid variables of a given Scid (GetSC --> parse vars), we can conclude it is a valid SCID. Otherwise, skip adding to validated scids
 			if len(v.scVars) > 0 {
 				indexer.Lock()

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -384,7 +384,7 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 						}
 					}
 
-					err := indexer.AddSCIDToIndex(scidstoadd, indexer.FastSyncConfig.SkipFSRecheck)
+					err := indexer.AddSCIDToIndex(scidstoadd, indexer.FastSyncConfig.SkipFSRecheck, false)
 					if err != nil {
 						logger.Errorf("[StartDaemonMode-fastsync] ERR - adding scids to index - %v", err)
 					}
@@ -741,7 +741,7 @@ func (indexer *Indexer) StartWalletMode(runType string) {
 }
 
 // Manually add/inject a SCID to be indexed. Checks validity and then stores within owner tree (no signer addr) and stores a set of current variables.
-func (indexer *Indexer) AddSCIDToIndex(scidstoadd map[string]*structures.FastSyncImport, skipfsrecheck bool) (err error) {
+func (indexer *Indexer) AddSCIDToIndex(scidstoadd map[string]*structures.FastSyncImport, skipfsrecheck bool, varstoreonly bool) (err error) {
 	var wg sync.WaitGroup
 	wg.Add(len(scidstoadd))
 
@@ -761,7 +761,7 @@ func (indexer *Indexer) AddSCIDToIndex(scidstoadd map[string]*structures.FastSyn
 	for scid, fsi := range scidstoadd {
 		go func(scid string, fsi *structures.FastSyncImport) {
 			// Check if already validated
-			if scidExist(indexer.ValidatedSCs, scid) || indexer.Closing {
+			if scidExist(indexer.ValidatedSCs, scid) || indexer.Closing && !varstoreonly {
 				//logger.Debugf("[AddSCIDToIndex] SCID '%v' already in validated list.", scid)
 				wg.Done()
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -164,7 +164,7 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 	}
 
 	if len(pre_validatedSCIDs) > 0 {
-		logger.Printf("[StartDaemonMode] Appending pre-validated SCIDs from store to memory.")
+		logger.Printf("[StartDaemonMode] Appending '%d' pre-validated SCIDs from store to memory.", len(pre_validatedSCIDs))
 
 		for k := range pre_validatedSCIDs {
 			if scidExist(indexer.SFSCIDExclusion, k) {
@@ -404,12 +404,13 @@ func (indexer *Indexer) StartDaemonMode(blockParallelNum int) {
 	if blockParallelNum <= 0 {
 		blockParallelNum = 1
 	}
-	logger.Printf("[StartDaemonMode] Set number of parallel blocks to index to '%v'", blockParallelNum)
+	logger.Printf("[StartDaemonMode] Set number of parallel blocks to index to '%d'. Starting index routine...", blockParallelNum)
 
 	go func() {
 		k := 0
 		for {
 			if indexer.Closing {
+				logger.Printf("[StartDaemonMode] Closing indexer...")
 				// Break out on closing call
 				break
 			}

--- a/structures/globals.go
+++ b/structures/globals.go
@@ -16,7 +16,7 @@ const TESTNET_GNOMON_SCID = "c9d23d2fc3aaa8e54e238a2218c0e5176a6e48780920fd8474f
 const MAX_API_VAR_RETURN = 1024
 
 // Major.Minor.Patch-Iteration
-var Version = semver.MustParse("2.0.0-alpha.1")
+var Version = semver.MustParse("2.0.1-alpha.1")
 
 // Hardcoded Smart Contracts of DERO Network
 // TODO: Possibly in future we can pull this from derohe codebase

--- a/structures/structures.go
+++ b/structures/structures.go
@@ -62,6 +62,11 @@ type SCIDVariable struct {
 	Value interface{}
 }
 
+type FastSyncConfig struct {
+	Enabled       bool
+	SkipFSRecheck bool
+}
+
 type FastSyncImport struct {
 	Owner   string
 	Height  uint64


### PR DESCRIPTION
## Description

Provides option for decreasing fastsync times by skipping re-validation checks on the scid data flowing from the gnomon sc.

Fixes #16 

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (fix or feature that would cause existing functionality to not work as expected or existing DBs to be re-synced)
- [x] This change requires a documentation update

## Which part is impacted ?

  - [x] Indexer
  - [x] GnomonSC
  - [ ] API
  - [ ] Storage
  - [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [ ] I have performed a full chain re-scan (if applicable)
- [x] I have updated the semver version (structures.Version)

## License

I am contributing & releasing the code under the MIT License (which can be found [here](https://raw.githubusercontent.com/civilware/Gnomon/main/LICENSE)).