### PR TITLE
Add daemon connection support for various prefixes

### DIFF
--- a/indexer/client.go
+++ b/indexer/client.go
@@ -27,6 +27,8 @@ type Client struct {
 }
 
 func (client *Client) Connect(endpoint string) (err error) {
+	var daemon_uri string
+
 	// Used to check if the endpoint has changed.. if so, then close WS to current and update WS
 	if client.WS != nil {
 		remAddr := client.WS.RemoteAddr()
@@ -43,20 +45,45 @@ func (client *Client) Connect(endpoint string) (err error) {
 		}
 	}
 
-	client.WS, _, err = websocket.DefaultDialer.Dial("ws://"+endpoint+"/ws", nil)
+	// Trim off http, https, wss, ws to get endpoint to use for connecting
+	if strings.HasPrefix(endpoint, "http") {
+		ld := strings.TrimPrefix(strings.ToLower(endpoint), "http://")
+		daemon_uri = "ws://" + ld + "/ws"
+
+		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(endpoint, "https") {
+		ld := strings.TrimPrefix(strings.ToLower(endpoint), "https://")
+		daemon_uri = "wss://" + ld + "/ws"
+
+		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(endpoint, "wss") {
+		ld := strings.TrimPrefix(strings.ToLower(endpoint), "wss://")
+		daemon_uri = "wss://" + ld + "/ws"
+
+		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(endpoint, "ws") {
+		ld := strings.TrimPrefix(strings.ToLower(endpoint), "ws://")
+		daemon_uri = "ws://" + ld + "/ws"
+
+		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else {
+		daemon_uri = "ws://" + endpoint + "/ws"
+
+		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	}
 
 	// notify user of any state change
 	// if daemon connection breaks or comes live again
 	if err == nil {
 		if !Connected {
-			logger.Printf("[Connect] Connection to RPC server successful - ws://%s/ws", endpoint)
+			logger.Printf("[Connect] Connection to RPC server successful - %s", daemon_uri)
 			Connected = true
 		}
 	} else {
 		logger.Errorf("[Connect] ERROR connecting to endpoint %v", err)
 
 		if Connected {
-			logger.Errorf("[Connect] ERROR - Connection to RPC server Failed - ws://%s/ws", endpoint)
+			logger.Errorf("[Connect] ERROR - Connection to RPC server Failed - %s", daemon_uri)
 		}
 		Connected = false
 		return err

--- a/indexer/client.go
+++ b/indexer/client.go
@@ -46,14 +46,14 @@ func (client *Client) Connect(endpoint string) (err error) {
 	}
 
 	// Trim off http, https, wss, ws to get endpoint to use for connecting
-	if strings.HasPrefix(endpoint, "http") {
-		ld := strings.TrimPrefix(strings.ToLower(endpoint), "http://")
-		daemon_uri = "ws://" + ld + "/ws"
-
-		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
-	} else if strings.HasPrefix(endpoint, "https") {
+	if strings.HasPrefix(endpoint, "https") {
 		ld := strings.TrimPrefix(strings.ToLower(endpoint), "https://")
 		daemon_uri = "wss://" + ld + "/ws"
+
+		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
+	} else if strings.HasPrefix(endpoint, "http") {
+		ld := strings.TrimPrefix(strings.ToLower(endpoint), "http://")
+		daemon_uri = "ws://" + ld + "/ws"
 
 		client.WS, _, err = websocket.DefaultDialer.Dial(daemon_uri, nil)
 	} else if strings.HasPrefix(endpoint, "wss") {

--- a/structures/globals.go
+++ b/structures/globals.go
@@ -19,7 +19,7 @@ const MAX_API_VAR_RETURN = 1024
 const FORCE_FASTSYNC_DIFF = int64(100)
 
 // Major.Minor.Patch-Iteration
-var Version = semver.MustParse("2.0.3-alpha.5")
+var Version = semver.MustParse("2.0.3-alpha.6")
 
 // Hardcoded Smart Contracts of DERO Network
 // TODO: Possibly in future we can pull this from derohe codebase


### PR DESCRIPTION
## Description

Adds support for daemon endpoints defined as http:// , https:// , wss:// , ws:// etc.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (fix or feature that would cause existing functionality to not work as expected or existing DBs to be re-synced)
- [ ] This change requires a documentation update

## Which part is impacted ?

  - [x] Indexer
  - [ ] GnomonSC
  - [ ] API
  - [ ] Storage
  - [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] My changes generate no new warnings
- [ ] I have performed a full chain re-scan (if applicable)
- [ ] I have updated the semver version (structures.Version)

## License

I am contributing & releasing the code under the MIT License (which can be found [here](https://raw.githubusercontent.com/civilware/Gnomon/main/LICENSE)).